### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,9 @@ references:
     restore_cache:
         <<: *npm_cache_keys
 
-  filters_only_master: &filters_only_master
+  filters_only_main: &filters_only_main
     branches:
-      only: master
+      only: main
 
   filters_ignore_tags: &filters_ignore_tags
     tags:
@@ -168,7 +168,7 @@ workflows:
       - schedule:
           cron: "0 0 * * *"
           filters:
-            <<: *filters_only_master
+            <<: *filters_only_main
     jobs:
       - build:
           context: next-nightly-build


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes. <br/><br/>This PR was created using a nori script<br/><br/>_Nori is a command-line application for managing changes across multiple (usually Github) repositories._